### PR TITLE
TLCPM-88 - reformat /migrated and /migrations panels

### DIFF
--- a/public/views/projects-migrated.html
+++ b/public/views/projects-migrated.html
@@ -7,28 +7,30 @@
 	  		<div class="col-md-4 col-lg-4 col-sm-4 col-xs-4">	
 	  		</div>
 	</h4>	
-	<div class="well">
-	  <ul class="list-group" style="margin-bottom:0">
-	  	<li class="list-group-item row" ng-repeat="tool in migratedProject.tools" ng-init="showDetails=[]">
-	    		<div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
-	    			{{tool.tool_name}}
-		  		</div>
-		  		<div class="col-md-4 col-lg-4 col-sm-4 col-xs-4">	
-		  			<small>Exported to <a href="tool.destination_url">{{tool.destination_type}}</a></small>
-		  		</div>
-		  		<div class="col-md-2 col-lg-2 col-sm-2 col-xs-2">	
-		  			<button ng-click="showDetails[$index] = !showDetails[$index]" class="btn btn btn-xs btn-link"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span><span class="sr-only">Information on migration of {{tool.tool_name}} for {{migratedProject.site_name}}</span></button>		  			
-		  		</div>
-		  		<div class="row" ng-show="showDetails[$index]">
-		  			<div class="col-md-6 col-lg-6 col-sm-6 col-xs-6" style="padding-left:30px">
-							<small>{{tool.start}} - {{tool.start}}</small>
-		  			</div>
-		  			<div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
-		  				<small> Migrated by {{tool.migrated_by}}</small>
-		  			</div>
-	  	</li>
-	  </ul>	
-	</div>
+		<div class="row">
+		<div class="col-md-12 col-lg-12 col-sm-12 col-xs-12">
+		  <ul class="list-group" style="margin:0 15px">
+		  	<li class="list-group-item row" ng-repeat="tool in migratedProject.tools" ng-init="showDetails=[]">
+		    		<div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
+		    			{{tool.tool_name}}
+			  		</div>
+			  		<div class="col-md-4 col-lg-4 col-sm-4 col-xs-4">	
+			  			<small>Exported to <a href="tool.destination_url">{{tool.destination_type}}</a></small>
+			  		</div>
+			  		<div class="col-md-2 col-lg-2 col-sm-2 col-xs-2">	
+			  			<button ng-click="showDetails[$index] = !showDetails[$index]" class="btn btn btn-xs btn-link"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span><span class="sr-only">Information on migration of {{tool.tool_name}} for {{migratedProject.site_name}}</span></button>		  			
+			  		</div>
+			  		<div class="row" ng-show="showDetails[$index]">
+			  			<div class="col-md-6 col-lg-6 col-sm-6 col-xs-6" style="padding-left:30px">
+								<small>{{tool.start}} - {{tool.start}}</small>
+			  			</div>
+			  			<div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
+			  				<small> Migrated by {{tool.migrated_by}}</small>
+			  			</div>
+		  	</li>
+		  </ul>	
+		</div>
+
 </div>
 
 <div ng-hide="migratedProjects.length">


### PR DESCRIPTION
New data format is tool/migration centric. For the Migrations panel, use the model unchanged (tool centric) because polling compares previous with current data set and changing the model will confuse things. But present in the UI categorized by site without changing the model.

For the Migrated panel, reorder the data so that it is categorized by site. Migrated panel is never polled, so rearranging the model is not an issue.
