### PR TITLE
TLCPM-346 adding the email formatter wiring for the Email archive module

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,22 @@ Spring Boot (https://github.com/spring-projects/spring-boot) makes it easy to cr
 * "mvn clean verify" will run the JMeter script for default profile, according to settings in pom.xml
 * Allow people from certain MCommunity Group specify end user id in the tool URL. Please refer to application_template.properties file for the configuration settings.
 
+## Unit Testing Email Archive Messages
+ Testing each Email message is returned as RFC822 format for Email Archive migration to the Google Groups.
+     The `EmailFormatter.java`class takes a single email message in the string json format. 
+     The EmailFormatter class can give various email formats like rfc822 complaint format, Mbox format etc. For RFC822 email
+     format generation takes all the headers provided by ctools and pruning headers that contains `content-type`. For email attachments,
+     ctools is providing attachment link instead of Base64 encoded string. So we are extracting the content from the attachment
+     and encode the content to base64. We are actually getting the base64 encoding using java mail service. We using the java
+     mail service for generating the email text and appending the existing header from ctools with email text from 
+     mail services. The pruning of email headers from ctools containing `content-type` is done as these headers are created 
+     when generating the email text from  mail service so if having then they will be like duplicate headers and email messages
+     will not be imported to Google groups.
+ 
+* under `/src/test/java` add the values for ctools url/password/username so could access the email messages from the Ctools.
+* Sample Email messages are added under `/src/test/java` as `message.json` or `message_1.json` used for the junit testing.
+  For more example of email message go to https://ctqa.dsc.umich.edu/direct/mailarchive/describe and access the message
+* `EmailFormatterTest.java` has various test associated so that a valid RFC822 email message is returned. Simlarly
+   `AttachmentHandlerTest.java` has test related to email attachment content.
+
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Spring Boot (https://github.com/spring-projects/spring-boot) makes it easy to cr
 * "mvn clean verify" will run the JMeter script for default profile, according to settings in pom.xml
 * Allow people from certain MCommunity Group specify end user id in the tool URL. Please refer to application_template.properties file for the configuration settings.
 
+## JUnit Test
+* By Default the Junit test are skipped when issue `mvn package` command inorder to run the build including Junit test do `mvn package -DskipTests=false`
+
 ## Unit Testing Email Archive Messages
  Testing each Email message is returned as RFC822 format for Email Archive migration to the Google Groups.
      The `EmailFormatter.java`class takes a single email message in the string json format. 

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,11 @@
 			<artifactId>commons-io</artifactId>
 			<version>1.3.2</version>
 		</dependency>
+       		 <dependency>
+            		<groupId>org.apache.commons</groupId>
+            		<artifactId>commons-lang3</artifactId>
+            		<version>3.0</version>
+        	</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
-    
+
 	<groupId>edu.umich.its</groupId>
 	<artifactId>ctools-project-migration</artifactId>
 	<version>0.1.0</version>
-    
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
@@ -15,7 +15,7 @@
 	</parent>
 
 	<packaging>war</packaging>
-	
+
 	<profiles>
 		<profile>
 			<id>local</id>
@@ -58,8 +58,8 @@
 			</properties>
 		</profile>
   </profiles>
-	
-	
+
+
 	<dependencies>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
@@ -228,14 +228,25 @@
 			<version>2.4</version>
 		</dependency>
 	</dependencies>
-	
+
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
-			<plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skipTests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.6</version>
@@ -300,7 +311,7 @@
 					</goals>
 					<configuration>
 						<!--
-							An AntPath-Style pattern matching a JMeter XML result file to analyze. 
+							An AntPath-Style pattern matching a JMeter XML result file to analyze.
 							Must be a fully qualified path.
 							File may be GZiped, must end in .gz then.
 							Default: not set.

--- a/src/main/java/edu/umich/its/cpm/AttachmentHandler.java
+++ b/src/main/java/edu/umich/its/cpm/AttachmentHandler.java
@@ -1,0 +1,70 @@
+package edu.umich.its.cpm;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.HashMap;
+
+/**
+ * Created by pushyami on 8/26/16.
+ */
+public class AttachmentHandler {
+    private static final Logger log = LoggerFactory.getLogger(AttachmentHandler.class);
+    private HttpServletRequest request;
+
+    @Autowired
+    private Environment env;
+
+    public Environment getEnv() {
+        return env;
+    }
+
+    public void setEnv(Environment env) {
+        this.env = env;
+    }
+
+    public AttachmentHandler(HttpServletRequest req){
+        this.request =req;
+    }
+
+    public byte[] getAttachmentContent(String attachmentUrl) {
+
+        byte[] attachmentContent = null;
+        String currentUserId = Utils.getCurrentUserId(request, env);
+        HashMap<String, Object> sessionAttributes = Utils.login_becomeuser(env, request, currentUserId);
+        if(sessionAttributes.isEmpty()){
+            log.error("Logging into Ctools failed for the user: "+currentUserId);
+            return attachmentContent;
+        }
+        String sessionId = (String) sessionAttributes.get(Utils.SESSION_ID);
+        HttpContext httpContext = (HttpContext) sessionAttributes.get("httpContext");
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        try {
+            HttpGet request = new HttpGet(attachmentUrl + "?_sessionId=" + sessionId);
+            request.setHeader("Content-Type", "application/x-www-form-urlencoded");
+            HttpResponse response = httpClient.execute(request, httpContext);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                log.error(String.format("Failure to read the attachment \"%1$s\" content in a Email Message " +
+                        "with status code %2$d ", attachmentUrl,statusCode ));
+                return attachmentContent;
+            }
+            attachmentContent = EntityUtils.toByteArray(response.getEntity());
+
+        } catch (IOException e) {
+            log.error("Failure in reading the attachment content for the Email Message" + e);
+        }
+        return attachmentContent;
+    }
+
+}

--- a/src/main/java/edu/umich/its/cpm/EmailFormatter.java
+++ b/src/main/java/edu/umich/its/cpm/EmailFormatter.java
@@ -1,0 +1,161 @@
+package edu.umich.its.cpm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+
+import javax.activation.DataHandler;
+import javax.mail.BodyPart;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.Session;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Created by pushyami on 8/17/16.
+ */
+public class EmailFormatter {
+    private static final Logger log = LoggerFactory.getLogger(EmailFormatter.class);
+    public AttachmentHandler attachmentHandler;
+
+    private String emailMessage;
+
+    @Autowired
+    private Environment env;
+
+    Map<String, Object> messageMap = null;
+
+    public EmailFormatter(String emailMgs, AttachmentHandler attachmentHandler) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        this.emailMessage = emailMgs;
+        this.attachmentHandler = attachmentHandler;
+        this.messageMap = mapper.readValue(this.emailMessage, new TypeReference<HashMap<String, Object>>(){});
+    }
+
+    public String rfc822Format() {
+        StringBuilder emailInRFCFormat = new StringBuilder();
+        ArrayList<String> headers = prunedHeadersWithoutContentType();
+        for (String header : headers) {
+            emailInRFCFormat.append(header);
+            emailInRFCFormat.append("\r\n");
+        }
+        String bodyAndAttachment = emailTextWithBodyAndAttachment(getEmailText());
+        emailInRFCFormat.append(bodyAndAttachment);
+        return emailInRFCFormat.toString();
+    }
+
+    public String getBody() {
+        return (String) messageMap.get("body");
+    }
+
+    public ArrayList<String> getHeaders() {
+        ArrayList<String> headers = (ArrayList<String>) messageMap.get("headers");
+        return headers;
+    }
+    //we are taking out all the headers that  contains "content-type" as these are again created again with
+    // getEmailText() call
+    public ArrayList<String> prunedHeadersWithoutContentType() {
+        ArrayList<String> prunedHeaders = new ArrayList<String>();
+        for (String header : getHeaders()) {
+            if (!StringUtils.containsIgnoreCase(header, "content-type")) {
+                prunedHeaders.add(header);
+            }
+        }
+        return prunedHeaders;
+    }
+
+    public HashMap<String, ArrayList<String>> getAttachments() {
+        HashMap<String, ArrayList<String>> attachmentMap = new HashMap<String, ArrayList<String>>();
+        ArrayList<HashMap<String, Object>> attachments = (ArrayList<HashMap<String, Object>>) messageMap.get("attachments");
+        for (HashMap<String, Object> attachment : attachments) {
+            final String mimeType = (String) attachment.get("type");
+            final String url = (String) attachment.get("url");
+            final String name = (String) attachment.get("name");
+            attachmentMap.put((String) attachment.get("id"), new ArrayList<String>() {{
+                add(mimeType);
+                add(name);
+                add(url);
+            }});
+        }
+        return attachmentMap;
+
+    }
+
+    /*
+     We are using java mailing services for generating the emailText. generally the mail services complaint with RFC822
+     Mime format.
+     */
+    public String getEmailText() {
+        Session session = null;
+        MimeMessage message = new MimeMessage(session);
+        String emailText = null;
+        try {
+            Multipart multipart = new MimeMultipart();
+
+            //Body of the email
+            BodyPart msgBodyPart = new MimeBodyPart();
+            String body = getBody();
+            if(!body.isEmpty()) {
+                msgBodyPart.setContent(body, "text/plain; charset=UTF-8");
+                multipart.addBodyPart(msgBodyPart);
+            }
+
+            // attachment part of email
+            HashMap<String, ArrayList<String>> attachments = getAttachments();
+            if (!attachments.isEmpty()) {
+                Set<String> attachmentIDs = attachments.keySet();
+                for (String id : attachmentIDs) {
+                    msgBodyPart = new MimeBodyPart();
+                    ArrayList<String> attachmentMetaData = attachments.get(id); // [Mimetype, fileName, attachmentUrl]
+                    String attachmentUrl = attachmentMetaData.get(2);
+                    String mimeType = attachmentMetaData.get(0);
+                    String fileName = attachmentMetaData.get(1);
+                    byte[] fileContent = attachmentHandler.getAttachmentContent(attachmentUrl);
+                    msgBodyPart.setDataHandler(new DataHandler(new ByteArrayDataSource(fileContent, mimeType)));
+                    msgBodyPart.setFileName(fileName);
+                    msgBodyPart.addHeader("Content-Transfer-Encoding", "base64");
+                    multipart.addBodyPart(msgBodyPart);
+
+                }
+
+            }
+            message.setContent(multipart);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            message.writeTo(output);
+            emailText = output.toString();
+
+        } catch (MessagingException e) {
+            log.error("Error occurred while generating the email stream" +e.getMessage());
+
+        } catch (IOException ioe) {
+            log.error("Error occurred while process writing the Mime message as stream" + ioe.getMessage());
+
+        }
+        return emailText;
+    }
+
+    public String emailTextWithBodyAndAttachment(String emailText) {
+        return subStringFrom(emailText, "Content-Type");
+    }
+
+    // Returns a substring containing all content starting from a specified string.
+    public String subStringFrom(String emailText, String contentToChopFrom) {
+        int posA = emailText.indexOf(contentToChopFrom);
+        if (posA == -1) {
+            return "";
+        }
+        return emailText.substring(posA);
+    }
+
+
+}

--- a/src/test/java/junit/edu/umich/its/cpmtest/AttachmentHandlerTest.java
+++ b/src/test/java/junit/edu/umich/its/cpmtest/AttachmentHandlerTest.java
@@ -1,0 +1,74 @@
+package junit.edu.umich.its.cpmtest;
+
+import edu.umich.its.cpm.AttachmentHandler;
+import junit.framework.TestCase;
+import org.junit.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+/**
+ * Created by pushyami on 8/26/16.
+ */
+
+public class AttachmentHandlerTest extends TestCase {
+
+    private AttachmentHandler attachmentHandler;
+
+    @Autowired
+    public Environment env;
+
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        HttpServletRequest request = null;
+        attachmentHandler = new AttachmentHandler(request);
+        attachmentHandler.setEnv(getMockEnvironment());
+
+    }
+
+    public static MockEnvironment getMockEnvironment() throws IOException {
+        MockEnvironment mockEnv = new MockEnvironment();
+        Properties props = getProps();
+        mockEnv.setProperty("ctools.server.url", (String)props.get("ctools.server.url"));
+        mockEnv.setProperty("username", (String)props.get("username"));
+        mockEnv.setProperty("password", (String)props.get("password"));
+        return mockEnv;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    public static Properties getProps() throws IOException {
+        Properties props = new Properties();
+        InputStream input = new FileInputStream(Paths.get(".").toAbsolutePath()+"/src/test/java/junit/edu/umich/its/cpmtest/test.properties");
+        props.load(input);
+        input.close();
+        return props;
+    }
+
+
+    public void testAttachment() {
+        String attachmentUrl = "https://ctdevsearch.dsc.umich.edu/access/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/dad9cffd-7aec-4896-83f5-23a4b2acacc3/email_msg.txt";
+        String attachmentContent = new String(attachmentHandler.getAttachmentContent(attachmentUrl));
+        assertEquals("This is a test.", attachmentContent);
+
+    }
+
+}

--- a/src/test/java/junit/edu/umich/its/cpmtest/EmailFormatterTest.java
+++ b/src/test/java/junit/edu/umich/its/cpmtest/EmailFormatterTest.java
@@ -66,8 +66,7 @@ public class EmailFormatterTest extends TestCase {
                 assertEquals("text/plain", attachmentData.get(0));
                 assertEquals("email_msg.txt", attachmentData.get(1));
                 assertEquals("https://ctdevsearch.dsc.umich.edu/access/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/dad9cffd-7aec-4896-83f5-23a4b2acacc3/email_msg.txt", attachmentData.get(2));
-            } else
-                System.out.println("The Attachment Id's in \"message.json\" and in the \"testAttachment()\" is different. Hence the passing test");
+            }
         }
     }
 
@@ -103,7 +102,7 @@ public class EmailFormatterTest extends TestCase {
         expected.append("VGhpcyBpcyBhIHRlc3Qu");expected.append("\r\n");
         expected.append("--XXX--");
         String emailText = formatter.rfc822Format();
-        System.out.println(emailText);
+//        System.out.println(emailText);
         assertEquals(expected.toString(), replaceTheBoundaryValue(emailText));
     }
 

--- a/src/test/java/junit/edu/umich/its/cpmtest/EmailFormatterTest.java
+++ b/src/test/java/junit/edu/umich/its/cpmtest/EmailFormatterTest.java
@@ -1,0 +1,120 @@
+package junit.edu.umich.its.cpmtest;
+
+import edu.umich.its.cpm.AttachmentHandler;
+import edu.umich.its.cpm.EmailFormatter;
+import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+/**
+ * Created by pushyami on 8/17/16.
+ */
+public class EmailFormatterTest extends TestCase {
+    Map<String, Object> messageSimple = null;
+    EmailFormatter formatter;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        HttpServletRequest request = null;
+        AttachmentHandler attachmentHandler = new AttachmentHandler(request);
+        attachmentHandler.setEnv(AttachmentHandlerTest.getMockEnvironment());
+        //read json file data to String
+        Path path = Paths.get(Paths.get(".").toAbsolutePath() + "/src/test/java/junit/edu/umich/its/cpmtest/message.json");
+        byte[] jsonData = Files.readAllBytes(path);
+        formatter = new EmailFormatter(new String(jsonData, Charset.defaultCharset()), attachmentHandler);
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    public void testMessageBody() {
+        String body = formatter.getBody();
+        assertEquals("This is so awesome to find out and unbelievable", body);
+    }
+
+    public void testMessageHeader() {
+        ArrayList<String> headers = formatter.prunedHeadersWithoutContentType();
+        assertEquals(17, headers.size());
+    }
+
+    public void testAttachment() {
+        HashMap<String, ArrayList<String>> attachments = formatter.getAttachments();
+        assertEquals(1, attachments.size());
+        Set<String> attachmentIDs = attachments.keySet();
+        for (String id : attachmentIDs) {
+            ArrayList<String> attachmentData = attachments.get(id);
+            if (id.equals("234")) {
+                assertEquals("text/plain", attachmentData.get(0));
+                assertEquals("email_msg.txt", attachmentData.get(1));
+                assertEquals("https://ctdevsearch.dsc.umich.edu/access/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/dad9cffd-7aec-4896-83f5-23a4b2acacc3/email_msg.txt", attachmentData.get(2));
+            } else
+                System.out.println("The Attachment Id's in \"message.json\" and in the \"testAttachment()\" is different. Hence the passing test");
+        }
+    }
+
+    public void testSimpleMsgInRFCFormat() {
+        StringBuilder expected = new StringBuilder();
+        expected.append("Received: from localhost ([127.0.0.1]) by special.dsc.umich.edu (JAMES SMTP Server 2.3.2) with SMTP ID 505 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 10:05:49 -0400 (EDT)");expected.append("\r\n");
+        expected.append("Received: from snowwhite.mr.itd.umich.edu (tl-nonprod-asb-nat1.dsc.umich.edu [141.211.192.39]) by special.dsc.umich.edu (Postfix) with ESMTP id E6687D12 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 10:05:48 -0400 (EDT)");expected.append("\r\n");
+        expected.append("Authentication-Results: snowwhite.mr.itd.umich.edu; iprev=pass policy.iprev=209.85.218.51 (mail-oi0-f51.google.com); spf=pass smtp.mailfrom=pushyami@umich.edu; dkim=pass header.d=@umich.edu; dmarc=pass header.from=pushyami@umich.edu");expected.append("\r\n");
+        expected.append("Received: FROM mail-oi0-f51.google.com (mail-oi0-f51.google.com [209.85.218.51]) By snowwhite.mr.itd.umich.edu ID 57BDA9BC.A4ED8.16927; Wed, 24 Aug 2016 10:05:48 -0400");expected.append("\r\n");
+        expected.append("Received: by mail-oi0-f51.google.com with SMTP id l203so23580020oib.1 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 07:05:48 -0700 (PDT)");expected.append("\r\n");
+        expected.append("DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=umich.edu; s=google-2016-06-03; h=mime-version:from:date:message-id:subject:to; bh=oUoLQKlJPbgYSuIbM0Q9NKsvPzE4kQZdoQ0tLeQTVMI=; b=dX39Sn3PsAWrj3XtgUH16uKd7wh9rKcMs3nnQItRtDrrUeCemm5JvGCqI2Ijof00qX B6c+QiYiLKqErYmPjcus0pV9NPtIOVHjzfny9NTdN/x4W2t5RuAA4/UWdFeQLwUNu7Ob sWhfYFEZ/NLzaM8zx3HKEmyWME9WjNVzghTn+7XiJUK8NZhjK8JdkmMo6riinpjUKOuo rTacFY9D+2dZiwmbmdLpKbGQpmuMtji6JMzWb+w5V8mQNqxwKgmJWu28IRvFMXClj6pZ luZnwaVneT8IJXS9IITvtviBsAiP3VVa+7jCZ5bxps8qoaCzrFk6+5OWbHaoYCeXI1Rx 2Okw==");expected.append("\r\n");
+        expected.append("X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=1e100.net; s=20130820; h=x-gm-message-state:mime-version:from:date:message-id:subject:to; bh=oUoLQKlJPbgYSuIbM0Q9NKsvPzE4kQZdoQ0tLeQTVMI=; b=CuOrgWbfv8oDieFegCYnQvsp2uxOA6LXziOhqluGFOn8FWh/ip7ZT7jbW9HcTWviZX Evhy/ZFZzArLWcPyrTYOJte3efc8DTifqJdTMJegk3NkzBEHdSNsnutv6Bhq6ixV6mBY Gbwd/6fRZqwmXfQQU7hRfALrHDU/ToM2M7ik9MhLIe549PwckpvMh0itX7Iq76e5gxw9 Bu3mbGpp6Baps5376n4nMoL2FABFdx3aoZzfEnzX3V8vd6vaJcVsIlB6BK90U1Z74WFz 4Tcn4gn9s0ZI+GL1V5L5WY8HsxfUjxx86c7lvDLP6gnLXgPGOa4/rUO4HbFeC3XMeX9C ac9Q==");expected.append("\r\n");
+        expected.append("X-Gm-Message-State: AE9vXwMpqaquA72LrOHQbYN5ihTcoMfjWfIDUjeG7pQusxFwQ2Kz8GfY9/UnJg1n/TtoVIuYOMdyOdA7F+motGbBOzU=");expected.append("\r\n");
+        expected.append("X-Received: by 10.157.4.79 with SMTP id 73mr2560093otc.29.1472047487817; Wed, 24 Aug 2016 07:04:47 -0700 (PDT)");expected.append("\r\n");
+        expected.append("MIME-Version: 1.0");expected.append("\r\n");
+        expected.append("Received: by 10.202.86.196 with HTTP; Wed, 24 Aug 2016 07:04:47 -0700 (PDT)");expected.append("\r\n");
+        expected.append("From: Pushyami Gundala <pushyami@umich.edu>");expected.append("\r\n");
+        expected.append("Date: Wed, 24 Aug 2016 10:04:47 -0400");expected.append("\r\n");
+        expected.append("Message-ID: <CAF8WsuqBzODBcc5-d_6yEgoyQhi13+bpLHjMNWP=g088YR=-5w@mail.gmail.com>");expected.append("\r\n");
+        expected.append("Subject: I figured it out");expected.append("\r\n");
+        expected.append("To: pushyami-test@ctqa.dsc.umich.edu");expected.append("\r\n");
+        expected.append("List-Id: <main.localhost>");expected.append("\r\n");
+        expected.append("Content-Type: multipart/mixed; ");expected.append("\r\n");
+        expected.append("\tboundary=\"XXX\"");expected.append("\r\n");expected.append("\r\n");
+        expected.append("--XXX");expected.append("\r\n");
+        expected.append("Content-Type: text/plain; charset=UTF-8");expected.append("\r\n");
+        expected.append("Content-Transfer-Encoding: 7bit");expected.append("\r\n");expected.append("\r\n");
+        expected.append("This is so awesome to find out and unbelievable");expected.append("\r\n");
+        expected.append("--XXX");expected.append("\r\n");
+        expected.append("Content-Type: text/plain; charset=UTF-8; name=email_msg.txt");expected.append("\r\n");
+        expected.append("Content-Transfer-Encoding: base64");expected.append("\r\n");
+        expected.append("Content-Disposition: attachment; filename=email_msg.txt");expected.append("\r\n");expected.append("\r\n");
+        expected.append("VGhpcyBpcyBhIHRlc3Qu");expected.append("\r\n");
+        expected.append("--XXX--");
+        String emailText = formatter.rfc822Format();
+        System.out.println(emailText);
+        assertEquals(expected.toString(), replaceTheBoundaryValue(emailText));
+    }
+
+    public String replaceTheBoundaryValue(String emailText) {
+        int posA = emailText.indexOf("boundary=");
+        String substring= emailText.substring(posA + 10);
+        int endIndex = substring.indexOf("\"");
+        String boundaryValue = substring.substring(0, endIndex);
+        String editedEmailText = emailText.replaceAll(boundaryValue, "XXX").trim();
+        return editedEmailText;
+    }
+
+
+}

--- a/src/test/java/junit/edu/umich/its/cpmtest/message.json
+++ b/src/test/java/junit/edu/umich/its/cpmtest/message.json
@@ -1,0 +1,44 @@
+{
+  "attachments": [
+
+    {
+      "id": "234",
+      "name": "email_msg.txt",
+      "ref": "/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/dad9cffd-7aec-4896-83f5-23a4b2acacc3/email_msg.txt",
+      "type": "text/plain",
+      "url": "https://ctdevsearch.dsc.umich.edu/access/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/dad9cffd-7aec-4896-83f5-23a4b2acacc3/email_msg.txt"
+    }
+
+  ],
+  "body": "This is so awesome to find out and unbelievable",
+  "headers": [
+    "Received: from localhost ([127.0.0.1]) by special.dsc.umich.edu (JAMES SMTP Server 2.3.2) with SMTP ID 505 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 10:05:49 -0400 (EDT)",
+    "Received: from snowwhite.mr.itd.umich.edu (tl-nonprod-asb-nat1.dsc.umich.edu [141.211.192.39]) by special.dsc.umich.edu (Postfix) with ESMTP id E6687D12 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 10:05:48 -0400 (EDT)",
+    "Authentication-Results: snowwhite.mr.itd.umich.edu; iprev=pass policy.iprev=209.85.218.51 (mail-oi0-f51.google.com); spf=pass smtp.mailfrom=pushyami@umich.edu; dkim=pass header.d=@umich.edu; dmarc=pass header.from=pushyami@umich.edu",
+    "Received: FROM mail-oi0-f51.google.com (mail-oi0-f51.google.com [209.85.218.51]) By snowwhite.mr.itd.umich.edu ID 57BDA9BC.A4ED8.16927; Wed, 24 Aug 2016 10:05:48 -0400",
+    "Received: by mail-oi0-f51.google.com with SMTP id l203so23580020oib.1 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 07:05:48 -0700 (PDT)",
+    "DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=umich.edu; s=google-2016-06-03; h=mime-version:from:date:message-id:subject:to; bh=oUoLQKlJPbgYSuIbM0Q9NKsvPzE4kQZdoQ0tLeQTVMI=; b=dX39Sn3PsAWrj3XtgUH16uKd7wh9rKcMs3nnQItRtDrrUeCemm5JvGCqI2Ijof00qX B6c+QiYiLKqErYmPjcus0pV9NPtIOVHjzfny9NTdN/x4W2t5RuAA4/UWdFeQLwUNu7Ob sWhfYFEZ/NLzaM8zx3HKEmyWME9WjNVzghTn+7XiJUK8NZhjK8JdkmMo6riinpjUKOuo rTacFY9D+2dZiwmbmdLpKbGQpmuMtji6JMzWb+w5V8mQNqxwKgmJWu28IRvFMXClj6pZ luZnwaVneT8IJXS9IITvtviBsAiP3VVa+7jCZ5bxps8qoaCzrFk6+5OWbHaoYCeXI1Rx 2Okw==",
+    "X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=1e100.net; s=20130820; h=x-gm-message-state:mime-version:from:date:message-id:subject:to; bh=oUoLQKlJPbgYSuIbM0Q9NKsvPzE4kQZdoQ0tLeQTVMI=; b=CuOrgWbfv8oDieFegCYnQvsp2uxOA6LXziOhqluGFOn8FWh/ip7ZT7jbW9HcTWviZX Evhy/ZFZzArLWcPyrTYOJte3efc8DTifqJdTMJegk3NkzBEHdSNsnutv6Bhq6ixV6mBY Gbwd/6fRZqwmXfQQU7hRfALrHDU/ToM2M7ik9MhLIe549PwckpvMh0itX7Iq76e5gxw9 Bu3mbGpp6Baps5376n4nMoL2FABFdx3aoZzfEnzX3V8vd6vaJcVsIlB6BK90U1Z74WFz 4Tcn4gn9s0ZI+GL1V5L5WY8HsxfUjxx86c7lvDLP6gnLXgPGOa4/rUO4HbFeC3XMeX9C ac9Q==",
+    "X-Gm-Message-State: AE9vXwMpqaquA72LrOHQbYN5ihTcoMfjWfIDUjeG7pQusxFwQ2Kz8GfY9/UnJg1n/TtoVIuYOMdyOdA7F+motGbBOzU=",
+    "X-Received: by 10.157.4.79 with SMTP id 73mr2560093otc.29.1472047487817; Wed, 24 Aug 2016 07:04:47 -0700 (PDT)",
+    "MIME-Version: 1.0",
+    "Received: by 10.202.86.196 with HTTP; Wed, 24 Aug 2016 07:04:47 -0700 (PDT)",
+    "From: Pushyami Gundala <pushyami@umich.edu>",
+    "Date: Wed, 24 Aug 2016 10:04:47 -0400",
+    "Message-ID: <CAF8WsuqBzODBcc5-d_6yEgoyQhi13+bpLHjMNWP=g088YR=-5w@mail.gmail.com>",
+    "Subject: I figured it out",
+    "To: pushyami-test@ctqa.dsc.umich.edu",
+    "X-Content-Type-Outer-Envelope: multipart/mixed; boundary=001a113dd7289acb9f053ad1c3ea",
+    "content-type: multipart/mixed; boundary=001a113dd7289acb9f053ad1c3ea",
+    "ConTent-Type: text/plain; charset=UTF-8",
+    "List-Id: <main.localhost>"
+  ],
+  "id": "49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3",
+  "mailArchiveMessageId": "de88268b-75b7-4837-8435-004b8be842a3",
+  "siteId": "49659c28-28a1-49ed-be2b-2d9848022e0d",
+  "siteTitle": "ADABRD 313 001 W16",
+  "subject": "I figured it out",
+  "entityReference": "/mailarchive/49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3",
+  "entityURL": "https://ctqa.dsc.umich.edu/direct/mailarchive/49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3",
+  "entityId": "49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3"
+}

--- a/src/test/java/junit/edu/umich/its/cpmtest/message_1.json
+++ b/src/test/java/junit/edu/umich/its/cpmtest/message_1.json
@@ -1,0 +1,58 @@
+{
+  "attachments": [
+    {
+      "id": "123",
+      "name": "email_msg.txt",
+      "ref": "/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/dad9cffd-7aec-4896-83f5-23a4b2acacc3/email_msg.txt",
+      "type": "text/plain",
+      "url": "https://ctdevsearch.dsc.umich.edu/access/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/dad9cffd-7aec-4896-83f5-23a4b2acacc3/email_msg.txt"
+    },
+    {
+      "id": "234",
+      "name": "Screen Shot 2015-04-07 at 1.26.27 PM.png",
+      "ref": "/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/79ae24c5-fbda-4b6c-901b-aff896045a8c/Screen Shot 2015-04-07 at 1.26.27 PM.png",
+      "type": "image/png",
+      "url": "https://ctdevsearch.dsc.umich.edu/access/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/79ae24c5-fbda-4b6c-901b-aff896045a8c/Screen%20Shot%202015-04-07%20at%201.26.27%20PM.png"
+    },
+    {
+      "id": "345",
+      "name": "What_is_the_piece_trash_we_used.pdf",
+      "ref": "/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/5dea69ce-7869-42c7-b834-346556c78e6b/What_is_the_piece_trash_we_used.pdf",
+      "type": "application/pdf",
+      "url": "https://ctdevsearch.dsc.umich.edu/access/content/attachment/03f0e860-5d58-45a6-9226-bbcde27830c2/_anon_/5dea69ce-7869-42c7-b834-346556c78e6b/What_is_the_piece_trash_we_used.pdf"
+    }
+
+
+  ],
+  "body": "This is so awesome to find out and unbelievable",
+  "headers": [
+    "Received: from localhost ([127.0.0.1]) by special.dsc.umich.edu (JAMES SMTP Server 2.3.2) with SMTP ID 505 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 10:05:49 -0400 (EDT)",
+    "Received: from snowwhite.mr.itd.umich.edu (tl-nonprod-asb-nat1.dsc.umich.edu [141.211.192.39]) by special.dsc.umich.edu (Postfix) with ESMTP id E6687D12 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 10:05:48 -0400 (EDT)",
+    "Authentication-Results: snowwhite.mr.itd.umich.edu; iprev=pass policy.iprev=209.85.218.51 (mail-oi0-f51.google.com); spf=pass smtp.mailfrom=pushyami@umich.edu; dkim=pass header.d=@umich.edu; dmarc=pass header.from=pushyami@umich.edu",
+    "Received: FROM mail-oi0-f51.google.com (mail-oi0-f51.google.com [209.85.218.51]) By snowwhite.mr.itd.umich.edu ID 57BDA9BC.A4ED8.16927; Wed, 24 Aug 2016 10:05:48 -0400",
+    "Received: by mail-oi0-f51.google.com with SMTP id l203so23580020oib.1 for <pushyami-test@ctqa.dsc.umich.edu>; Wed, 24 Aug 2016 07:05:48 -0700 (PDT)",
+    "DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=umich.edu; s=google-2016-06-03; h=mime-version:from:date:message-id:subject:to; bh=oUoLQKlJPbgYSuIbM0Q9NKsvPzE4kQZdoQ0tLeQTVMI=; b=dX39Sn3PsAWrj3XtgUH16uKd7wh9rKcMs3nnQItRtDrrUeCemm5JvGCqI2Ijof00qX B6c+QiYiLKqErYmPjcus0pV9NPtIOVHjzfny9NTdN/x4W2t5RuAA4/UWdFeQLwUNu7Ob sWhfYFEZ/NLzaM8zx3HKEmyWME9WjNVzghTn+7XiJUK8NZhjK8JdkmMo6riinpjUKOuo rTacFY9D+2dZiwmbmdLpKbGQpmuMtji6JMzWb+w5V8mQNqxwKgmJWu28IRvFMXClj6pZ luZnwaVneT8IJXS9IITvtviBsAiP3VVa+7jCZ5bxps8qoaCzrFk6+5OWbHaoYCeXI1Rx 2Okw==",
+    "X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=1e100.net; s=20130820; h=x-gm-message-state:mime-version:from:date:message-id:subject:to; bh=oUoLQKlJPbgYSuIbM0Q9NKsvPzE4kQZdoQ0tLeQTVMI=; b=CuOrgWbfv8oDieFegCYnQvsp2uxOA6LXziOhqluGFOn8FWh/ip7ZT7jbW9HcTWviZX Evhy/ZFZzArLWcPyrTYOJte3efc8DTifqJdTMJegk3NkzBEHdSNsnutv6Bhq6ixV6mBY Gbwd/6fRZqwmXfQQU7hRfALrHDU/ToM2M7ik9MhLIe549PwckpvMh0itX7Iq76e5gxw9 Bu3mbGpp6Baps5376n4nMoL2FABFdx3aoZzfEnzX3V8vd6vaJcVsIlB6BK90U1Z74WFz 4Tcn4gn9s0ZI+GL1V5L5WY8HsxfUjxx86c7lvDLP6gnLXgPGOa4/rUO4HbFeC3XMeX9C ac9Q==",
+    "X-Gm-Message-State: AE9vXwMpqaquA72LrOHQbYN5ihTcoMfjWfIDUjeG7pQusxFwQ2Kz8GfY9/UnJg1n/TtoVIuYOMdyOdA7F+motGbBOzU=",
+    "X-Received: by 10.157.4.79 with SMTP id 73mr2560093otc.29.1472047487817; Wed, 24 Aug 2016 07:04:47 -0700 (PDT)",
+    "MIME-Version: 1.0",
+    "Received: by 10.202.86.196 with HTTP; Wed, 24 Aug 2016 07:04:47 -0700 (PDT)",
+    "From: Pushyami Gundala <pushyami@umich.edu>",
+    "Date: Wed, 24 Aug 2016 10:04:47 -0400",
+    "Message-ID: <CAF8WsuqBzODBcc5-d_6yEgoyQhi13+bpLHjMNWP=g088YR=-5w@mail.gmail.com>",
+    "Subject: I figured it out",
+    "To: pushyami-test@ctqa.dsc.umich.edu",
+    "X-Content-Type-Outer-Envelope: multipart/mixed; boundary=001a113dd7289acb9f053ad1c3ea",
+    "content-type: multipart/mixed; boundary=001a113dd7289acb9f053ad1c3ea",
+    "ConTent-Type: text/plain; charset=UTF-8",
+    "List-Id: <main.localhost>"
+  ],
+  "id": "49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3",
+  "mailArchiveMessageId": "de88268b-75b7-4837-8435-004b8be842a3",
+  "siteId": "49659c28-28a1-49ed-be2b-2d9848022e0d",
+  "siteTitle": "ADABRD 313 001 W16",
+  "subject": "I figured it out",
+  "entityReference": "/mailarchive/49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3",
+  "entityURL": "https://ctqa.dsc.umich.edu/direct/mailarchive/49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3",
+  "entityId": "49659c28-28a1-49ed-be2b-2d9848022e0d:main:de88268b-75b7-4837-8435-004b8be842a3"
+}

--- a/src/test/java/junit/edu/umich/its/cpmtest/test.properties
+++ b/src/test/java/junit/edu/umich/its/cpmtest/test.properties
@@ -1,0 +1,3 @@
+ctools.server.url=http://google.com
+username=test_user
+password=eeeee

--- a/src/test/java/junit/edu/umich/its/cpmtest/test.properties
+++ b/src/test/java/junit/edu/umich/its/cpmtest/test.properties
@@ -1,3 +1,3 @@
 ctools.server.url=http://google.com
 username=test_user
-password=eeeee
+password=MY_BEAUTIFUL_BUT_USELESS_NONPASSWORD


### PR DESCRIPTION
The Outcome of this jira is formatting a single email message to RFC822 standard. 
Introduced 2 new class called `EmailFormatter` and `AttachmentHandler`( dealing with the attachment in the email message). 
The `EmailFormatter` takes the message which is nothing but a Json in the string format and convert to a RFC822 complaint string. The code is only tested by writing JUnit test since the wiring to getting the Email archives is not hooked up yet and hence relied on the Junit test cases. 

@zqian @dlhaines 
