### PR TITLE
TLCPM-309: add pom profile to include oracle db driver.  Standardize formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,20 @@
 				<maven.httpRequest.serverPort>80</maven.httpRequest.serverPort>
 			</properties>
 		</profile>
-  </profiles>
+		<profile>
+			<id>db-driver-oracle</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>ojdbc7</artifactId>
+					<version>12.1.0.2</version>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 
 	<dependencies>
@@ -158,13 +171,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-        <!--
-       <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>ojdbc7</artifactId>
-            <version>12.1.0.2</version>
-            </dependency>
-            -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -184,9 +190,9 @@
 		</dependency>
 		<!-- Box integration -->
 		<dependency>
-    		<groupId>com.box</groupId>
-    		<artifactId>box-java-sdk</artifactId>
-    		<version>2.1.1</version>
+			<groupId>com.box</groupId>
+			<artifactId>box-java-sdk</artifactId>
+			<version>2.1.1</version>
 		</dependency>
 		<!-- Apache Commons IO -->
 		<dependency>
@@ -194,11 +200,11 @@
 			<artifactId>commons-io</artifactId>
 			<version>1.3.2</version>
 		</dependency>
-       		 <dependency>
-            		<groupId>org.apache.commons</groupId>
-            		<artifactId>commons-lang3</artifactId>
-            		<version>3.0</version>
-        	</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
@@ -225,9 +231,9 @@
 		</dependency>
 	</dependencies>
 
-    <properties>
-        <skipTests>true</skipTests>
-    </properties>
+	<properties>
+		<skipTests>true</skipTests>
+	</properties>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
The pom profile is optional.  To include in maven build explicitly invoke with "-P db-driver-oracle".
This is useful for running CPM from within eclipse but doesn't affect the current builds.
