### PR TITLE
TLCPM-696: automatically create backup table when run read-only changes

### DIFF
--- a/src/sql/READ_ONLY/generateROSqlSite.pl
+++ b/src/sql/READ_ONLY/generateROSqlSite.pl
@@ -304,8 +304,7 @@ sub printForSites {
 sub readFromStdin {
   
   # make a backup table.
-  ## make these by hand once.
-  #  writeRRFTableBackupSql($task);
+  writeRRFTableBackupSql($task) if ($task eq "READ_ONLY_UPDATE");
 
   printPermissionsCount("initial count");
 


### PR DESCRIPTION
automatically create backup table when run read-only changes