### PR TITLE
TLCPM-773 handle the comma in site title that prevents zip download

### DIFF
--- a/src/main/java/edu/umich/its/cpm/Utils.java
+++ b/src/main/java/edu/umich/its/cpm/Utils.java
@@ -120,7 +120,7 @@ class Utils {
 	// Specify characters that can't appear in folder / file names
 	// Need lots and lots of backslashes to correctly quote backslashes used for escaping regex characters.
 	// Will handle trailing forward slash as a special case.
-	public static final String SANITIZE_CHARACTERS = ":/><*\\\\\"|\\?";
+	public static final String SANITIZE_CHARACTERS = ",:/><*\\\\\"|\\?";
 	public static final String SANITIZE_CHARACTERS_REGEX = "["+SANITIZE_CHARACTERS+"]";
 	public static Pattern SANITIZE_CHARACTERS_PATTERN = Pattern.compile(Utils.SANITIZE_CHARACTERS_REGEX);
 	public static final String SANITIZE_SPACES = "\t";


### PR DESCRIPTION
If the zip file name contains a comma, it won't be properly downloaded via browser. 

The solution is to escape the comma character with an underscore.