### PR TITLE
Fixes #526 - Set a range locked version for jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,8 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>[2.9.9.1,)</version>
+			<!-- Don't go higher than 2.9.x -->
+			<version>[2.9.10.3,2.10)</version>
 		</dependency>
 		<!-- axis
 		<dependency>


### PR DESCRIPTION
This project doesn't seem to be compatible with jackson-databind 2.10 or higher, only 2.9.x. This previous version range wasn't limited on the upper end.